### PR TITLE
CLD-848 Update role for cloud-ops

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-haproxy_exporter_bin_dir: "/usr/local/bin"
+haproxy_exporter_bin_dir: /opt/haproxy-exporter
 haproxy_exporter_development_node: False
 haproxy_exporter_listen_port: 9101
 haproxy_exporter_log_level: "info"
@@ -8,7 +8,6 @@ haproxy_exporter_scrape_uri: "unix:/run/haproxy/admin.sock"
 
 # Comma-separated list of exported server metrics. See
 # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1
-haproxy_exporter_server_metric_fields: "2,3,4,5,6,7,8,9,13,14,15,16,17,18,21,24,33,35,38,39,40,41,42,43,44"
 haproxy_exporter_service_enabled: "yes"
 haproxy_exporter_service_state: "started"
 haproxy_exporter_ssl_verify: True
@@ -16,4 +15,4 @@ haproxy_exporter_state: "present"
 haproxy_exporter_system_group: "haproxy"
 haproxy_exporter_system_user: "haproxy-exp"
 haproxy_exporter_timeout: "5s"
-haproxy_exporter_version: "0.9.0"
+haproxy_exporter_version: "0.10.0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-haproxy_exporter_bin_dir: /opt/haproxy-exporter
+haproxy_exporter_bin_dir: /usr/local/bin
 haproxy_exporter_development_node: False
 haproxy_exporter_listen_port: 9101
 haproxy_exporter_log_level: "info"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
   no_log: true
   notify: restart haproxy_exporter
 
-- name:  start and enable haproxy_exporter service
+- name: start and enable haproxy_exporter service
   become: true
   systemd:
     name: haproxy_exporter
@@ -91,10 +91,7 @@
     url: http://localhost:9101/metrics
     return_content: yes
   register: metrics
-
-- name: debug
-  debug:
-    var: metrics
+  changed_when: false
 
 - name: fail when haproxy-exporter unable to collect metrics
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,15 +34,6 @@
     state: "{{ haproxy_exporter_state }}"
     system: true
 
-- name: create haproxy_exporter directory
-  become: true
-  file:
-    path: "{( haproxy_exporter_bin_dir }}"
-    state: directory
-    owner: "{{ haproxy_exporter_system_user }}"
-    group: "{{ haproxy_exporter_system_group }}"
-    mode: '0644'
-
 - name: ensure tar is installed
   package:
     name: tar
@@ -52,7 +43,7 @@
   become: true
   get_url:
     url: "https://github.com/prometheus/haproxy_exporter/releases/download/v{{ haproxy_exporter_version }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
     checksum: "sha256:{{ __haproxy_exporter_checksum }}"
   register: _download_binary
   until: _download_binary is succeeded
@@ -61,10 +52,20 @@
 
 - name: unarchive haproxy_exporter binary
   unarchive:
-    src: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "{{ haproxy_exporter_bin_dir }}"
+    src: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: /tmp
     remote_src: true
     creates: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/haproxy_exporter"
+
+- name: propagate haproxy_exporter binary
+  become: true
+  copy:
+    src: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/haproxy_exporter"
+    dest: "{{ haproxy_exporter_bin_dir}}/haproxy_exporter"
+    remote_src: true
+    mode: 0750
+    owner: "{{ haproxy_exporter_system_user }}"
+    group: "{{ haproxy_exporter_system_group }}"
   notify: restart haproxy_exporter
 
 - name: copy haproxy_exporter systemd service file
@@ -91,7 +92,6 @@
     url: http://localhost:9101/metrics
     return_content: yes
   register: metrics
-  changed_when: false
 
 - name: fail when haproxy-exporter unable to collect metrics
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
       systemd: 
         name: haproxy
         state: started
-        enabled: yes
+        enabled: true
   when:
     - haproxy_exporter_development_node
 
@@ -34,40 +34,37 @@
     state: "{{ haproxy_exporter_state }}"
     system: true
 
-- name: ensure tar is installed
+- name: create haproxy_exporter directory
   become: true
+  file:
+    path: "{( haproxy_exporter_bin_dir }}"
+    state: directory
+    owner: "{{ haproxy_exporter_system_user }}"
+    group: "{{ haproxy_exporter_system_group }}"
+    mode: '0644'
+
+- name: ensure tar is installed
   package:
     name: tar
     state: present
 
-- name: download haproxy_exporter binary to local folder
+- name: download haproxy_exporter binary
+  become: true
   get_url:
     url: "https://github.com/prometheus/haproxy_exporter/releases/download/v{{ haproxy_exporter_version }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
     checksum: "sha256:{{ __haproxy_exporter_checksum }}"
   register: _download_binary
   until: _download_binary is succeeded
   retries: 5
   delay: 2
-  delegate_to: localhost
-  check_mode: False
 
 - name: unarchive haproxy_exporter binary
   unarchive:
-    src: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: /tmp
-    creates: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/haproxy_exporter"
-  delegate_to: localhost
-  check_mode: False
-
-- name: propagate haproxy_exporter binary
-  become: true
-  copy:
-    src: "/tmp/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/haproxy_exporter"
-    dest: "{{ haproxy_exporter_bin_dir}}/haproxy_exporter"
-    mode: 0750
-    owner: "{{ haproxy_exporter_system_user }}"
-    group: "{{ haproxy_exporter_system_group }}"
+    src: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "{{ haproxy_exporter_bin_dir }}"
+    remote_src: true
+    creates: "{{ haproxy_exporter_bin_dir }}/haproxy_exporter-{{ haproxy_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/haproxy_exporter"
   notify: restart haproxy_exporter
 
 - name: copy haproxy_exporter systemd service file
@@ -78,23 +75,26 @@
     owner: root
     group: root
     mode: 0644
-  # Prevent Ansible from displaying password
   no_log: true
   notify: restart haproxy_exporter
 
-- name: ensure haproxy_exporter is enabled
+- name:  start and enable haproxy_exporter service
   become: true
   systemd:
     name: haproxy_exporter
     enabled: "{{ haproxy_exporter_service_enabled }}"
     state: "{{ haproxy_exporter_service_state }}"
+    daemon_reload: true
 
 - name: curl haproxy-exporter metrics
   uri:
     url: http://localhost:9101/metrics
     return_content: yes
   register: metrics
-  check_mode: no
+
+- name: debug
+  debug:
+    var: metrics
 
 - name: fail when haproxy-exporter unable to collect metrics
   fail:

--- a/templates/haproxy_exporter.service.j2
+++ b/templates/haproxy_exporter.service.j2
@@ -15,7 +15,6 @@ ExecStart={{ haproxy_exporter_bin_dir}}/haproxy_exporter \
 {% endif %}
     --web.listen-address=":{{ haproxy_exporter_listen_port }}" \
     --haproxy.scrape-uri="{{ haproxy_exporter_scrape_uri }}" \
-    --haproxy.server-metric-fields="{{ haproxy_exporter_server_metric_fields }}" \
     --haproxy.timeout={{ haproxy_exporter_timeout }} \
     --haproxy.pid-file="{{ haproxy_exporter_pid_file }}" \
     --log.level="{{ haproxy_exporter_log_level }}"


### PR DESCRIPTION
**Summary**

Revised this role to be more up-to-date with our current Ansible scheme.

Role did not work out of the box and some changes were made to work.

**Tests**

Confirmed working when HAproxy is configured correctly using PR: [https://github.com/webnifico/cloud-ops/pull/726](https://github.com/webnifico/cloud-ops/pull/726)

Confirmed that metrics are showing up:

```
stanleylam@keycloak-controller001-dev:~$ curl -s http://localhost:9101/metrics | grep "^haproxy"
haproxy_backend_bytes_in_total{backend="keycloak_be"} 0
haproxy_backend_bytes_out_total{backend="keycloak_be"} 0
haproxy_backend_connection_errors_total{backend="keycloak_be"} 0
haproxy_backend_current_queue{backend="keycloak_be"} 0
haproxy_backend_current_server{backend="keycloak_be"} 0
haproxy_backend_current_session_rate{backend="keycloak_be"} 0
haproxy_backend_current_sessions{backend="keycloak_be"} 0
haproxy_backend_http_connect_time_average_seconds{backend="keycloak_be"} 0
haproxy_backend_http_queue_time_average_seconds{backend="keycloak_be"} 0
haproxy_backend_http_response_time_average_seconds{backend="keycloak_be"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="1xx"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="2xx"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="3xx"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="4xx"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="5xx"} 0
haproxy_backend_http_responses_total{backend="keycloak_be",code="other"} 0
haproxy_backend_http_total_time_average_seconds{backend="keycloak_be"} 0
haproxy_backend_limit_sessions{backend="keycloak_be"} 200
haproxy_backend_max_queue{backend="keycloak_be"} 0
haproxy_backend_max_session_rate{backend="keycloak_be"} 0
haproxy_backend_max_sessions{backend="keycloak_be"} 0
haproxy_backend_redispatch_warnings_total{backend="keycloak_be"} 0
haproxy_backend_response_errors_total{backend="keycloak_be"} 0
haproxy_backend_retry_warnings_total{backend="keycloak_be"} 0
haproxy_backend_sessions_total{backend="keycloak_be"} 0
haproxy_backend_up{backend="keycloak_be"} 0
...
```